### PR TITLE
Add up2date link to aliexpress debug cable

### DIFF
--- a/content/docs/wiki/cc3200/debug-port.md
+++ b/content/docs/wiki/cc3200/debug-port.md
@@ -39,7 +39,7 @@ Datasheet: [Tag Connect TC2050-IDC-NL](https://www.tag-connect.com/wp-content/up
 
 Available at: [Tag Connect TC2050-IDC-NL](https://www.tag-connect.com/product/tc2050-idc-nl-10-pin-no-legs-cable-with-ribbon-connector)
 
-Alternative (cheaper): [PCB Clip 1.27mm 5 Pin Double Row](https://a.aliexpress.com/_BSuEeo)
+Alternative (cheaper): [PCB Clip 1.27mm 5 Pin Double Row](https://aliexpi.com/xJQX)
 
 # Boot Mode
 The CC3200 device implements a sense-on-power (SoP) scheme to switch between two modes that are available within the Tonie project. (To switch between the boot modes a restart of the device is needed.) [CC3200 datasheet 5.9.3](http://www.ti.com/lit/ds/symlink/cc3200.pdf)


### PR DESCRIPTION
closes #8

shortened link: https://de.aliexpress.com/item/4000926386894.html?algo_exp_id=951f44a1-dc29-4b58-9680-b9cee67a17e7-0&pdp_npi=4%40dis%21EUR%2119.35%2119.35%21%21%2120.66%21%21%40212c01e917048980240698441ee6c0%2112000024576771631%21sea%21DE%21790240599%21&curPageLogUid=u90Ee5GCE8Cu&utparam-url=scene%3Asearch%7Cquery_from%3A

with aliexpress URL shortener: https://aliexpi.com/