### PR TITLE
Added audio config spec

### DIFF
--- a/content/docs/wiki/general/500304E0.json config.md
+++ b/content/docs/wiki/general/500304E0.json config.md
@@ -1,0 +1,53 @@
+---
+title: "500304E0.json config"
+description: "Info about the 500304E0.json file"
+---
+# 500304E0.json
+Each folder on the Toniebox contains a file called `500304E0.json` alongside the actual audio content. This file contains the configuration for the content.
+
+Usually it looks like the following by default:
+
+```
+{
+	"live":	false,
+	"nocloud":	false,
+	"source":	"",
+	"skip_seconds":	0,
+	"cache":	false,
+	"cloud_ruid":	"",
+	"cloud_auth":	"",
+	"cloud_override":	false,
+	"tonie_model":	"",
+	"_version":	5
+}
+```
+
+## Specification
+| Option         | Type   | Default | Description |
+| live           | bool   | `false` |             |
+| nocloud        | bool   | `false` | Do not sync the directory with the boxine cloud |
+| source         | str    | `""`    |             |
+| skip_seconds   | uint32 | `0`     | Skips the audio by given seconds at the beginning |
+| cache          | bool   | `false` |             |
+| cloud_ruid     | str    | `""`    |             |
+| cloud_auth     | str    | `""`    |             |
+| cloud_override | bool   | `false` |             |
+| tonie_model    | str    | `""`    |             |
+| _version       | uint32 | `5`     |             |
+
+## Examples
+
+Custom audiobooks that you added to Teddycloud (no official Tonies) typically will have `nocloud` enabled:
+```
+TODO
+```
+
+Official Tonies will have the following default config:
+```
+TODO
+```
+
+You can download content right from an URL by setting the `source`. In combination with `nocloud` you can easily set up custom content:
+```
+TODO
+```


### PR DESCRIPTION
What I am missing is details about the content config. In order to learn (and enhance the docs in parallel) I tried putting together a skeleton of a wiki page describing the 500304E0.json.

This PR is meant to be WIP and I hope you could add a bit of your knowledge as well. In the end we'll have some useful info for future users.