### PR TITLE
Add documentation to inject hostname/IP via commandline

### DIFF
--- a/content/docs/tools/teddyCloud/flash-ca/esp32.md
+++ b/content/docs/tools/teddyCloud/flash-ca/esp32.md
@@ -5,7 +5,7 @@ description: ""
 
 # ESP32
 ## Browser based
-With teddyCloud you can also write a new image with your custom CA and a DNS/IP so the box connects to teddyCloud.
+With teddyCloud you can also write a new image with your custom CA and a hostname/IP so the box connects to teddyCloud.
 If you have a Fritzbox you can set it to tc.fritz.box (see CC3200 how to configure the hostname on your Fritzbox), if not set it to the IP of teddyCloud.
 
 Check, that your backup of your flash is okay and you were able to extract the certificates. 

--- a/content/docs/tools/teddyCloud/flash-ca/esp32.md
+++ b/content/docs/tools/teddyCloud/flash-ca/esp32.md
@@ -29,4 +29,26 @@ esptool.py -b 921600 write_flash 0x0 tb.esp32.fakeca.bin
 ![Flash ESP32 Image](/img/esp32_write_patched_image_with_esptools.png)
 
 
-[Please continue with DNS step for the ESP32](../../dns/esp32)
+Set the hostname/IP via commandline
+```
+# copy firmware backup
+cp tb.esp32.fakeca.bin tb.esp32.fakeca.IP.bin
+# inject new IP into firmware
+teddycloud ESP32HOST tb.esp32.fakeca.IP.bin 192.168.178.49
+# Fix the firmware, otherwise the TonieBox hang in a reboot loop
+teddycloud ESP32FIXUP tb.esp32.fakeca.IP.bin
+# flash firmware with new IP
+esptool.py -b 921600 write_flash 0x0 tb.esp32.fakeca.IP.bin
+```
+
+The output after injection of the hostname/IP should include the following lines
+```
+INFO |esp32.c:0990:esp32_patch_host()| Patching hostnames in 'tb.esp32.fakeca.IP.bin'
+INFO |esp32.c:1038:esp32_patch_host()|  replaced RTNL host 2 times
+INFO |esp32.c:1040:esp32_patch_host()|  replaced API host 2 times
+
+```
+If it states `0 times` than the hostname/IP is already changed (maybe to another value). ESP32HOST does only works on fwirmware with the original hostnames, as it does some search & replace.
+
+
+Alternatively, your Fritz.Box can configured to return your TeddyCloud IP during domain name resolution: [Domain Name resolution](../../dns/esp32)


### PR DESCRIPTION
See discussion at https://forum.revvox.de/t/setting-hostname-ip-the-legacy-way/339

I also changed DNS/IP to hostname/IP as my understanding is that the hostname is set and not the domain name server URL. But I kept that change in a separate commit. So feel free to not include it if it causes more confusion.