### PR TITLE
Uppercase file/foldernames

### DIFF
--- a/content/docs/tools/teddyCloud/_index.md
+++ b/content/docs/tools/teddyCloud/_index.md
@@ -31,7 +31,7 @@ If you have problems with teddyCloud or just want to be sure everything works as
 ## Additional
 
 ### Content
-Please put your content into the ```/data/content/default/``` in the same structure as on your toniebox. You can edit ```500304E0.json``` file beside the content files to mark them as live or you can prevent the usage of the Boxine cloud for that tag with the nocloud parameter. By setting a source teddyCloud can stream any content that ffmpeg can decode (urls and files). Foldernames need to be capitalized.
+Please put your content into the ```/data/content/default/``` in the same structure as on your toniebox. You can edit ```500304E0.json``` file beside the content files to mark them as live or you can prevent the usage of the Boxine cloud for that tag with the nocloud parameter. By setting a source teddyCloud can stream any content that ffmpeg can decode (urls and files). Please check that the file and folders in upper case. If not rename them, otherwise teddyCloud won't serve them to the box!
 
 ### Webinterface
 Currently the teddyCloud webinterface is reachable through the IP of the docker container at port 80 or 443 (depending on your ```docker-compose.yaml```). Changes affecting the toniebox (volume, LED) which are made through this interface will only be reflected onto the toniebox after pressing the big ear for a few seconds until a beep occurs. 

--- a/content/docs/tools/teddyCloud/_index.md
+++ b/content/docs/tools/teddyCloud/_index.md
@@ -31,7 +31,7 @@ If you have problems with teddyCloud or just want to be sure everything works as
 ## Additional
 
 ### Content
-Please put your content into the ```/data/content/default/``` in the same structure as on your toniebox. You can edit ```500304E0.json``` file beside the content files to mark them as live or you can prevent the usage of the Boxine cloud for that tag with the nocloud parameter. By setting a source teddyCloud can stream any content that ffmpeg can decode (urls and files).
+Please put your content into the ```/data/content/default/``` in the same structure as on your toniebox. You can edit ```500304E0.json``` file beside the content files to mark them as live or you can prevent the usage of the Boxine cloud for that tag with the nocloud parameter. By setting a source teddyCloud can stream any content that ffmpeg can decode (urls and files). Foldernames need to be capitalized.
 
 ### Webinterface
 Currently the teddyCloud webinterface is reachable through the IP of the docker container at port 80 or 443 (depending on your ```docker-compose.yaml```). Changes affecting the toniebox (volume, LED) which are made through this interface will only be reflected onto the toniebox after pressing the big ear for a few seconds until a beep occurs. 


### PR DESCRIPTION
I had erros when copying the foldernames 1:1 in the teddycloud. Foldernames on the SD card are lower case, while in Teddycloud the foldernames need to be upper case.