### PR TITLE
Fix link to "Supported Server Hardware"

### DIFF
--- a/content/docs/tools/teddyCloud/_index.md
+++ b/content/docs/tools/teddyCloud/_index.md
@@ -10,7 +10,7 @@ headless: true
 ## Features
 teddyCloud is an alternative server for your Toniebox, allowing you to host the cloud services locally.
 This gives you the control about which data is sent to the original manufacturer's cloud and allows you
-to host your own figurine audio files on e.g. your [NAS or any other server](supported-server-hardware). It provides an easy to use WebGui.
+to host your own figurine audio files on e.g. your [NAS or any other server](setup/supported-server-hardware). It provides an easy to use WebGui.
 
 ![teddyCloud Webinterface](/img/teddyCloudWebinterface.png)
 


### PR DESCRIPTION
Tiny fix: Link to "Supported Server Hardware" was dead.