### PR TITLE
Update test-troubleshooting.md

### DIFF
--- a/content/docs/tools/teddyCloud/setup/test-troubleshooting.md
+++ b/content/docs/tools/teddyCloud/setup/test-troubleshooting.md
@@ -5,7 +5,7 @@ bookCollapseSection: true
 ---
 # teddyCloud - Test & Troubleshooting
 ## Connection toniebox to teddyCloud
-First of all please be sure the cloud is not enabled in the webinterface. Then close all browser windows to teddyClouds webinterface and open the logs of teddyCloud. If you are using docker you can access them via: `docker logs teddyCloud`.
+First of all please be sure the cloud is not enabled in the webinterface. Then close all browser windows to teddyClouds webinterface and open the logs of teddyCloud. If you are using docker you can access them via: `docker logs teddycloud`.
 
 To be sure your toniebox can connect to teddyCloud we do a so called "freshnessCheck". This can be initiated by pressing one ear of the box until the LED is pulsing blue.
 


### PR DESCRIPTION
In the `docker-compose.yaml`, the container name is `teddycloud` (all lowercase), so to see the logs the correct command is `docker logs teddycloud`.
(Only a minor typo, but I stumbled over it.)