### PR TITLE
added link to debug-port wiki in cc3200.md

### DIFF
--- a/content/docs/tools/teddyCloud/setup/dump-certs/cc3200.md
+++ b/content/docs/tools/teddyCloud/setup/dump-certs/cc3200.md
@@ -4,7 +4,7 @@ description: ""
 ---
 
 # CC3200
-You can use the [cc3200tool](https://github.com/toniebox-reverse-engineering/cc3200tool) to dump your certificates over the Tag Connect debug port of the box. If you have installed the [HackieboxNG Bootloader](/docs/custom-firmware/cc3200/hackieboxng-bl/) you should already have those files in your backup. If not, you should install [HackieboxNG](/docs/custom-firmware/cc3200/hackieboxng-bl/). This will allow to to read and write files from/to microSD and flash by booting the [Hackiebox CFW](/docs/custom-firmware/cc3200/hackiebox-cfw).
+You can use the [cc3200tool](https://github.com/toniebox-reverse-engineering/cc3200tool) to dump your certificates over the Tag Connect [debug port](/docs/wiki/cc3200/debug-port.md) of the box. If you have installed the [HackieboxNG Bootloader](/docs/custom-firmware/cc3200/hackieboxng-bl/) you should already have those files in your backup. If not, you should install [HackieboxNG](/docs/custom-firmware/cc3200/hackieboxng-bl/). This will allow to to read and write files from/to microSD and flash by booting the [Hackiebox CFW](/docs/custom-firmware/cc3200/hackiebox-cfw).
 Please drop the three .der files to `/certs/client/`.
 
 ## Read certificates via Hackiebox CFW


### PR DESCRIPTION
I think the infos in the wiki about the debug port should be available here, so I created a link to the page at least.