### PR TITLE
add Docker Macvlan network documentation

### DIFF
--- a/content/docs/tools/teddyCloud/setup/_index.md
+++ b/content/docs/tools/teddyCloud/setup/_index.md
@@ -12,7 +12,7 @@ Minimal teddyCloud version for this docu is release v0.6.0! Please ensure you ar
 The docker container automatically generates the server certificates on first run. You can extract the ```certs/server/ca.der``` for your box after that. 
 
 An example [docker-compose.yaml can be found within the docker subdir.](https://github.com/toniebox-reverse-engineering/teddycloud/blob/master/docker/docker-compose.yaml)
-Please beware that port 443 cannot be remapped and you cannot use a reverse proxy like nginx or traefik without passing through the TLS (complex, not recommended). The client certificate authentication needs to be done by teddyCloud. Also, there is no SNI. If you are using docker, you can use macvlan to give the teddyCloud container a dedicated IP address (recommended).
+Please beware that port 443 cannot be remapped and you cannot use a reverse proxy like nginx or traefik without passing through the TLS (complex, not recommended). The client certificate authentication needs to be done by teddyCloud. Also, there is no SNI. If you are using docker, you can [use macvlan](docker-macvlan) to give the teddyCloud container a dedicated IP address (recommended).
 
 ## Preparation
 First of all, prepare your teddyCloud installation. On first run, teddyCloud generates its certificates. During the generation you cannot access the webinterface. This can take several minutes! Be sure you check the log output!

--- a/content/docs/tools/teddyCloud/setup/docker-macvlan.md
+++ b/content/docs/tools/teddyCloud/setup/docker-macvlan.md
@@ -1,0 +1,68 @@
+---
+title: "Docker Macvlan"
+description: "Use Docker Macvlan for a dedicated IP"
+bookCollapseSection: true
+headless: true
+---
+# Docker Macvlan Setup
+
+## Prerequisites
+
+Make sure, you have an IP address in your network, which does not get served by the local DHCP server.
+
+## Assumptions for this example
+
+In this example
+
+* the IP address 192.168.1.3 is reserved for teddycloud 
+* in a network 192.168.0.0/23
+* with the router having the address 192.168.0.1
+
+
+## Create Docker Macvlan Network
+
+You create a Docker Macvlan network with the following command:
+
+```
+docker network create \
+  --driver macvlan \
+  --subnet=192.168.0.0/23 \
+  --gateway=192.168.0.1 \
+  --ip-range=192.168.1.3/32 \
+  -o parent=eth1 \
+  teddycloud_macvlan
+```
+
+Of course you have to adapt all the parameters to your network.
+
+## Adjust docker-compose.yaml
+
+After the Docker Macvlan network has been created, it can be used in the `docker-compose.yaml`.
+
+### Add Docker Macvlan network
+
+At the end of you `docker-compose.yaml` add the following lines to add the Docker Macvlan network:
+
+```
+networks:
+  teddycloud_macvlan:
+    external: true
+```
+
+### Use Docker Macvlan in teddycloud service
+
+Add the networks secion to your teddycloud service, which are the last three lines of the following snippet
+
+```
+services:
+  teddycloud:
+    …
+    networks:
+      teddycloud_macvlan:
+        ipv4_address: 192.168.1.3
+```
+
+## Done
+
+Save the `docker-compose.yaml` file and start the container.
+


### PR DESCRIPTION
I started a short documentation for the Docker Macvlan setup for teddycloud. I was not able to test the generation with Hugo to check if everything works, because i only have hugo v0.140.0 installed, which errors:

```
$ hugo server
WARN  DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" instead.
Watching for changes in $HOME/toniebox-reverse-engineering.github.io/{archetypes,assets,content,static,themes}
Watching for config changes in $HOME/toniebox-reverse-engineering.github.io/hugo.toml
Start building sites … 
hugo v0.140.0+extended linux/amd64 BuildDate=unknown

ERROR deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.141.0. Use css.Sass instead.
WARN  Raw HTML omitted while rendering "$HOME/toniebox-reverse-engineering.github.io/content/docs/wiki/general/audio-file-format.md"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe
You can suppress this warning by adding the following to your site configuration:
ignoreLogs = ['warning-goldmark-raw-html']
WARN  Raw HTML omitted while rendering "$HOME/toniebox-reverse-engineering.github.io/content/docs/tools/teddyCloud/setup/flash-ca/cc3200.md"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe
You can suppress this warning by adding the following to your site configuration:
ignoreLogs = ['warning-goldmark-raw-html']
ERROR deprecated: .Sites.First was deprecated in Hugo v0.127.0 and will be removed in Hugo 0.141.0. Use .Sites.Default instead.
ERROR deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.141.0. Use hugo.IsMultilingual instead.
Built in 130 ms
Error: error building site: logged 3 error(s)
```