### PR TITLE
general: linux audio extract now considers actual header len

### DIFF
--- a/content/docs/wiki/general/audio-file-format.md
+++ b/content/docs/wiki/general/audio-file-format.md
@@ -76,6 +76,18 @@ But the in experiments used encoder did not have an obvious feature to do this.
 
 **We have developed a tool called [teddy](https://github.com/toniebox-reverse-engineering/teddy) to encode and decode these files.**
 
-# Audio file extraction with Linux OS
-- Remove Header of the file with ´dd bs=4096 skip=1 if=500304E0 of=trim.ogg´
-- then just use ffmpeg to convert it into mp3 ´ffmpeg -i trim.ogg done.mp3´
+# Audio file extraction with Linux OS and bash shell
+
+1. read the *header_len* (in hex): `dd status=none if=50012345 bs=1 count=4 | xxd -plain`
+2. convert to decimal and add 4 in order to get the length (in decimal) of the whole header
+3. read the audio_data into file: `dd if=50012345 bs=1 skip="${header_len}" of=50012345.audio_data.ogg`
+4. (optional) convert audio_data from ogg to mp3: `ffmpeg -i 50012345.audio_data.ogg 50012345.audio_data.mp3`
+
+The same procedure as one block of spagetthi code for easier copy&paste:
+
+```bash
+inputfile=50012345
+header_len="$((4+0x"$(dd status=none if="${inputfile}" bs=1 count=4 | xxd -plain)"))"
+dd if="${inputfile}" bs=1 skip="${header_len}" of=${inputfile}.audio_data.ogg
+ffmpeg -i "${inputfile}.audio_data.ogg" "${inputfile}.audio_data.mp3"
+```


### PR DESCRIPTION
Dear Maintainer,

i found the toniebox reverse engineering wiki very useful today. As a side-effect, i submit to you a change to the wiki content that hopefully is noted as improvement.

When recommending on how to convert a toniebox data file, the header_len can be easily extracted from the data file itself. Just in case the header_len is not the usual value of 0x0ffc.

Personally i find it easier, if the bash commands are presented as one block that can be copy&pasted with the input file as variable.

with best regards,

qyanu / Max-Julian Pogner
