### PR TITLE
doc: add samsung 512gb evo plus to compatibility list

### DIFF
--- a/content/docs/wiki/cc3200/microsd-compatibility.md
+++ b/content/docs/wiki/cc3200/microsd-compatibility.md
@@ -13,6 +13,8 @@ Here you find a list of working microSD cards for the box. It seems to be very p
 * 2GB SanDisk microSD
 * 32GB Micron microSDHC I 1
 * 32GB Perciron microSD (noname Aliexpress)
+## Samsung
+* 512GB Samsung EVO Plus microSDXC UHS-I Class 10 U3 (MB-MC512KA/EU)
 
 # Not Working
 ## Samsung


### PR DESCRIPTION
I have successfully added a Samsung 512GB EVO Plus to two CC3200 boxes.
The model of the microSDXC is MB-MC512KA/EU